### PR TITLE
Update sqlard.h

### DIFF
--- a/sqlard.h
+++ b/sqlard.h
@@ -297,6 +297,7 @@ public:
 #endif
 
 	static int freeRam(const char * who) {
+		// I got some compilation errors please look my comments
 		extern int __heap_start, *__brkval;
 		int v;
 		int fr = (int)&v - (__brkval == 0 ? (int)&__heap_start : (int)__brkval);
@@ -1115,7 +1116,7 @@ public:
 		void maintain() {
 			while (!m_pEthClient->connected()) {
 				Serial.println("retry connect");
-				/* Bağlanana kadar dene. */
+				/* BaÃ°lanana kadar dene. */
 				if (connect()) {
 					login();
 				}


### PR DESCRIPTION
I got the following error when running your code with Arduino 1.8.12:
sketch\MSSQL_esp.ino.cpp.o:(.text.ZN10SQLardUtil7freeRamEPKc[SQLardUtil::freeRam(char const*)]+0x0): undefined reference to `_brkval'

sketch\MSSQL_esp.ino.cpp.o:(.text.ZN10SQLardUtil7freeRamEPKc[SQLardUtil::freeRam(char const*)]+0x4): undefined reference to `_heap_start'